### PR TITLE
New feature: ephemereal jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `dockwrkr login` command for logging into all defined registries
+- Jobs feature. Define short-lived `jobs` in `dockwrkr.yml` which are executed
+  in an ad-hoc manner.
+
+### Changed
+- `dockwrkr.yml`: `containers` has been renamed to `services`. Support for the
+  `containers` key is maintained until next major release.
 
 ## [1.0.1] - 2017-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2017-11-15
+### Added
+- Jobs feature. Define short-lived `jobs` in `dockwrkr.yml` which are executed
+  in an ad-hoc manner.
+
+### Changed
+- The `containers` section of `dockwrkr.yml` has been renamed to `services`, however backward-compatibility for `containers` is still maintained.
+
 ## [1.1.2] - 2017-11-09
 
 ### Fixed
@@ -21,8 +29,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `dockwrkr login` command for logging into all defined registries
-- Jobs feature. Define short-lived `jobs` in `dockwrkr.yml` which are executed
-  in an ad-hoc manner.
 
 ### Changed
 - `dockwrkr.yml`: `containers` has been renamed to `services`. Support for the

--- a/README.md
+++ b/README.md
@@ -100,13 +100,13 @@ services:
     volume:
       - "/path/to/vol:/dest/of/vol"
 jobs:
-  hello-once:
+  print-foo-variables:
     image: busybox
     env:
       VAR_FOO_VAR: 1
       VAR_FOO_BAR: "string"
       VAR_FOO_VAR: null
-    command: /bin/sh -c "echo hello world"
+    command: ['/bin/sh', '-c', 'env | grep FOO']
     volume:
       - "/path/to/vol:/dest/of/vol"
 ```
@@ -224,10 +224,10 @@ host #
 Use this command to execute a jobs defined in the `jobs` section of
 `dockwrkr.yml`.
 
-Using the example configuration, you can execute the `say-hello` job like so:
+Using the example configuration, you can execute the `print-foo-variables` job like so:
 
 ```
-host # dockwrkr run hello-once
+host # dockwrkr run print-foo-variables
 ```
 
 You can pass additional parameters to the command; there will be appended to

--- a/dockwrkr/cli.py
+++ b/dockwrkr/cli.py
@@ -28,6 +28,7 @@ class DockwrkrCLI(Program):
         self.addCommand('exec', 'dockwrkr.command.exec')
         self.addCommand('stats', 'dockwrkr.command.stats')
         self.addCommand('login', 'dockwrkr.command.login')
+        self.addCommand('run', 'dockwrkr.command.run')
         return self
 
     def getShellOptions(self, optparser):

--- a/dockwrkr/command/run.py
+++ b/dockwrkr/command/run.py
@@ -1,0 +1,24 @@
+from dockwrkr import (Command)
+
+
+class Run(Command):
+
+    def getUsage(self):
+        return "dockwrkr run CONTAINER [ARGS...]"
+
+    def getHelpTitle(self):
+        return "Run the specified job container"
+
+    def execute(self, args=None):
+        # Do NOT allow interspersed options!
+        self.input = args
+        (self.options, self.args) = self.parseShellInput(False)
+        return self.main()
+
+    def main(self):
+        if not len(self.args) > 0:
+            return self.exitError("Please provide a job container to run.")
+        container = self.args[0]
+        container_args = self.args[1:]
+        return self.core.run(container, container_args) \
+            .catch(self.exitError)

--- a/dockwrkr/docker.py
+++ b/dockwrkr/docker.py
@@ -1,9 +1,12 @@
 import logging
+import os
+import arrow
+import subprocess
+
 from dockwrkr.monads import *
 from dockwrkr.shell import Shell
 from dockwrkr.utils import (ensureList, expandLocalPath, safeQuote)
-from dockwrkr.exceptions import ShellCommandError, DockerError
-import arrow
+from dockwrkr.exceptions import ShellCommandError, DockerError, InvalidConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -260,6 +263,19 @@ def unpackImageString(imageStr):
     return unpack
 
 
+def run(container, containerArgs, config, basePath=None, networks=None):
+    params = readCreateParameters(
+        container, config, basePath=basePath, networks=networks, asList=True)
+    if params.isFail():
+        return params
+    try:
+        cmd = [DOCKER_CLIENT, "run", "--rm", "--interactive", "--tty"] + params.getOK() + containerArgs
+        logger.debug("EXECVP - %s" % subprocess.list2cmdline([DOCKER_CLIENT] + cmd))
+        os.execvp(DOCKER_CLIENT, cmd)
+    except Exception as ex:
+        return Fail(ex)
+
+
 def execmd(container, cmd, tty=False, interactive=False, user=None, detach=None, privileged=None):
     opts = []
     if tty:
@@ -335,13 +351,13 @@ def readCreateNetworkParameters(network):
                 cmd_opt.append("--%s" % confkey)
         elif confkey in DOCKER_NETWORK_LIST_OPTIONS:
             if not isinstance(confval, (basestring, list, tuple)):
-                return InvalidConfigError(
-                    "[%s] Malformed option '%s': Should be string, number or list." % (network_name, confkey))
+                return Fail(InvalidConfigError(
+                    "[%s] Malformed option '%s': Should be string, number or list." % (network_name, confkey)))
             confval = ensureList(confval)
             for i, lv in enumerate(confval):
                 cmd_list.append("--%s=%s" % (confkey, safeQuote(lv)))
         else:
-            return InvalidConfigError("[%s] Unkown option '%s'." % (network_name, confkey))
+            return Fail(InvalidConfigError("[%s] Unkown option '%s'." % (network_name, confkey)))
 
     for part in cmd_opt:
         cmd.append(part)
@@ -364,7 +380,7 @@ def readCreateNetworkParameters(network):
     return OK(cmdline)
 
 
-def readCreateParameters(container, config, basePath=None, networks=None):
+def readCreateParameters(container, config, basePath=None, networks=None, asList=False):
 
     cconf = config.copy()
 
@@ -376,7 +392,7 @@ def readCreateParameters(container, config, basePath=None, networks=None):
     cconf['name'] = container
 
     if 'image' not in cconf:
-        return InvalidConfigError("[%s] Container has no 'image' defined." % (container))
+        return Fail(InvalidConfigError("[%s] Container has no 'image' defined." % (container)))
     image = cconf['image']
     del cconf['image']
 
@@ -422,15 +438,15 @@ def readCreateParameters(container, config, basePath=None, networks=None):
             elif confval is not None and (confval is False or confval.lower() in ["false", "no"] or confval == 0):
                 cmd_opt.append("--%s=%s" % (confkey, "false"))
             else:
-                return InvalidConfigError("[%s] Invalid value for option '%s' : Must be true or false." % (container, confkey))
+                return Fail(InvalidConfigError("[%s] Invalid value for option '%s' : Must be true or false." % (container, confkey)))
         elif confkey in DOCKER_LIST_OPTIONS:
             if not isinstance(confval, (basestring, list, tuple)):
-                return InvalidConfigError("[%s] Malformed option '%s': Should be string, number or list." % (container, confkey))
+                return Fail(InvalidConfigError("[%s] Malformed option '%s': Should be string, number or list." % (container, confkey)))
             confval = ensureList(confval)
             for i, lv in enumerate(confval):
                 cmd_list.append("--%s=%s" % (confkey, safeQuote(lv)))
         else:
-            return InvalidConfigError("[%s] Unkown option '%s'." % (container, confkey))
+            return Fail(InvalidConfigError("[%s] Unknown option '%s'." % (container, confkey)))
 
     for part in cmd_opt:
         cmd.append(part)
@@ -441,12 +457,17 @@ def readCreateParameters(container, config, basePath=None, networks=None):
     for extra in extra_flags:
         cmd.append(extra)
 
-    cmd.append("--label %s.name=\"%s\"" % (DOCKWRKR_LABEL_DOMAIN, container))
-    cmd.append("--label %s.managed=1" % DOCKWRKR_LABEL_DOMAIN)
+    cmd.append("--label")
+    cmd.append("%s.name=\"%s\"" % (DOCKWRKR_LABEL_DOMAIN, container))
+    cmd.append("--label")
+    cmd.append("%s.managed=1" % DOCKWRKR_LABEL_DOMAIN)
     cmd.append(image)
 
     if command:
         cmd.append("%s" % command)
+
+    if asList:
+        return OK(cmd)
 
     cmdline = ""
     for i, part in enumerate(cmd):

--- a/dockwrkr/docker.py
+++ b/dockwrkr/docker.py
@@ -270,7 +270,7 @@ def run(container, containerArgs, config, basePath=None, networks=None):
         return params
     try:
         cmd = [DOCKER_CLIENT, "run", "--rm", "--interactive", "--tty"] + params.getOK() + containerArgs
-        logger.debug("EXECVP - %s" % subprocess.list2cmdline([DOCKER_CLIENT] + cmd))
+        logger.debug("EXECVP - %s" % subprocess.list2cmdline(cmd))
         os.execvp(DOCKER_CLIENT, cmd)
     except Exception as ex:
         return Fail(ex)
@@ -396,9 +396,9 @@ def readCreateParameters(container, config, basePath=None, networks=None, asList
     image = cconf['image']
     del cconf['image']
 
-    command = None
+    command = []
     if 'command' in cconf:
-        command = cconf['command']
+        command = ensureList(cconf['command'])
         del cconf['command']
 
     extra_flags = []
@@ -463,8 +463,8 @@ def readCreateParameters(container, config, basePath=None, networks=None, asList
     cmd.append("%s.managed=1" % DOCKWRKR_LABEL_DOMAIN)
     cmd.append(image)
 
-    if command:
-        cmd.append("%s" % command)
+    for part in command:
+        cmd.append(part)
 
     if asList:
         return OK(cmd)


### PR DESCRIPTION
Allow executing one-off jobs using predefined container environment in
dockwrkr.yml. Jobs are named in a separate section.

Changes:
* Split "containers" config into "services" and "jobs" (with backward-compat for "containers" key)
* Add "run" command
* Fix Python crashes on invalid config

Resolves issue #3.