### PR TITLE
Enables flagging containers so they don't autostart

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ services:
   hello3:
     image: busybox
     hostname: hello1
+    autostart: false
     env:
       VAR_FOO_VAR: 1
       VAR_FOO_BAR: "string"
@@ -110,8 +111,9 @@ jobs:
       - "/path/to/vol:/dest/of/vol"
 ```
 
-Each parameter for each container definition (in `services` or `jobs`) match
-the ``docker run`` Docker client [options](https://docs.docker.com/engine/reference/run/#overriding-dockerfile-image-defaults).
+Each parameter for each container definition (in `services` or `jobs`) matches
+the ``docker run`` Docker client [options](https://docs.docker.com/engine/reference/run/#overriding-dockerfile-image-defaults)
+with the exception of [`autostart`](#startstop) which is only used internally.
 
 
 ### PIDs
@@ -149,7 +151,7 @@ qmgr               cf6766f0c39c   24364    172.17.0.5     1 months ago         -
 cron               45c26cf9c3d4   26279    172.17.0.10    1 months ago         -
 ```
 
-### start / stop
+### start/stop
 
 These commands will start or stop the specified containers.
 
@@ -162,7 +164,7 @@ These commands will start or stop the specified containers.
 
 You can affect multiple containers at once by listing them on the command line.
 Alternatively you can also use the `-a` switch to affect all defined
-containers.
+containers, except those flagged with `autostart: false`.
 
 ```
 # dockwrkr stop web cache

--- a/dockwrkr/docker.py
+++ b/dockwrkr/docker.py
@@ -391,6 +391,10 @@ def readCreateParameters(container, config, basePath=None, networks=None, asList
 
     cconf = config.copy()
 
+    # Autostart is only used by dockwrkr, we do not want to pass it to docker
+    if 'autostart' in cconf:
+        del cconf['autostart']
+
     if 'net' in cconf:
         if networks and cconf['net'] in networks:
             readNetworkExists({cconf['net']: networks[cconf['net']]}) \

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -34,8 +34,13 @@ class TestCore(tests.TestBase):
             self.assertIsInstance(core.start(containers=['hello1']), OK)
             self.assertIsInstance(core.start(containers=['hello2']), OK)
             self.assertIsInstance(core.start(containers=['hello3']), OK)
+            self.assertIsInstance(core.start(containers=['hello4']), OK)
             self.assertIsInstance(core.stop(all=True, time=0), OK)
             self.assertIsInstance(core.start(all=True), OK)
+
+            # Test hello4 has no PID
+            self.assertEqual('-', core.status(containers=['hello4']).getOK()[0][2])
+
             self.assertIsInstance(core.pull(all=True), OK)
             self.assertIsInstance(core.excmd(
                 container='hello1', cmd=['ls', '-al']), OK)

--- a/tests/dockwrkr-1.yml
+++ b/tests/dockwrkr-1.yml
@@ -47,3 +47,14 @@ services:
       VAR_FOO_BAR: "string"
       VAR_FOO_VAR: null
     command: /bin/sh -c "while true; do echo hello world; sleep 1; done"
+  hello4:
+    image: busybox
+    hostname: hello1
+    net: container-network3
+    autostart: false
+    ip: 172.21.0.16
+    env:
+      VAR_FOO_VAR: 1
+      VAR_FOO_BAR: "string"
+      VAR_FOO_VAR: null
+    command: /bin/sh -c "while true; do echo hello world; sleep 1; done"


### PR DESCRIPTION
Adds the `autostart` config flag that lets us stop containers from
starting when called with `dockwrkr start -a`.