### PR TITLE
fix: don't write pids as binary, they're just text

### DIFF
--- a/dockwrkr/utils.py
+++ b/dockwrkr/utils.py
@@ -115,7 +115,7 @@ def dateToAgo(time=False):
 
 def writeToFile(data, filename):
     try:
-        with open(filename, "wb") as fh:
+        with open(filename, "w") as fh:
             fh.write(data)
     except Exception as err:
         raise FileSystemError("Failed to write to %s : %s" % (filename, err))


### PR DESCRIPTION
Causes issues in Python 3+